### PR TITLE
Fix homepage widget comment typos

### DIFF
--- a/compose/hs/_template.yml
+++ b/compose/hs/_template.yml
@@ -52,7 +52,7 @@ services:
       - homepage.icon=cname.png
       - homepage.href=http://cname.$DOMAINNAME
       - homepage.weight=0
-      # Homepage Weidget Setup
+      # Homepage Widget Setup
       - homepage.widget.type=cname
       - homepage.widget.url=http://cname:80 # again, internal port for the container
       # - homepage.widget.key=$cname_api_key   

--- a/compose/hs/evcc.yml
+++ b/compose/hs/evcc.yml
@@ -57,7 +57,7 @@ services:
       - homepage.icon=evcm.png
       - homepage.href=http://evcc.$DOMAINNAME
       - homepage.weight=0
-      # Homepage Weidget Setup
+      # Homepage Widget Setup
       - homepage.widget.type=evcc
       - homepage.widget.url=http://evcc:7070 # again, internal port for the container
       # - homepage.widget.key=$evcc_api_key   

--- a/compose/hs/ghost.yml
+++ b/compose/hs/ghost.yml
@@ -55,7 +55,7 @@ services:
       # - homepage.icon=ghost.png
       # - homepage.href=http://ghost.$DOMAINNAME
       # - homepage.weight=0
-      # # Homepage Weidget Setup
+      # # Homepage Widget Setup
       # - homepage.widget.type=ghost
       # - homepage.widget.url=http://ghost:80 # again, internal port for the container
       # - homepage.widget.key=$ghost_api_key   

--- a/compose/hs/glances.yml
+++ b/compose/hs/glances.yml
@@ -52,7 +52,7 @@ services:
       # - homepage.icon=glances.png
       # - homepage.href=http://glances.$DOMAINNAME
       # - homepage.weight=0
-      # # Homepage Weidget Setup
+      # # Homepage Widget Setup
       # - homepage.widget.type=glances
       # - homepage.widget.url=http://glances:61208 # again, internal port for the container
       # - homepage.widget.version=4

--- a/compose/hs/homebridge.yml
+++ b/compose/hs/homebridge.yml
@@ -37,7 +37,7 @@ services:
       - homepage.icon=homebridge.png
       - homepage.href=http://homebridge.$DOMAINNAME
       - homepage.weight=0
-      # Homepage Weidget Setup
+      # Homepage Widget Setup
       - homepage.widget.type=homebridge
       - homepage.widget.url=http://homebridge:8581 # again, internal port for the container
       - homepage.widget.username=jeearle

--- a/compose/hs/kavita.yml
+++ b/compose/hs/kavita.yml
@@ -52,7 +52,7 @@ services:
       - homepage.icon=kavita.png
       - homepage.href=http://kavita.$DOMAINNAME
       - homepage.weight=0
-      # Homepage Weidget Setup
+      # Homepage Widget Setup
       - homepage.widget.type=kavita
       - homepage.widget.url=http://kavita:5000 # again, internal port for the container
       - homepage.widget.username=jeearle

--- a/compose/hs/vaultwarden.yml
+++ b/compose/hs/vaultwarden.yml
@@ -53,7 +53,7 @@ services:
       # - homepage.icon=vaultwarden.png
       # - homepage.href=http://vaultwarden.$DOMAINNAME
       # - homepage.weight=0
-      # # Homepage Weidget Setup
+      # # Homepage Widget Setup
       # - homepage.widget.type=vaultwarden
       # - homepage.widget.url=http://vaultwarden:80 # again, internal port for the container
       # # - homepage.widget.key=$vaultwarden_api_key   


### PR DESCRIPTION
## Summary
- correct typo `Weidget` to `Widget` in compose files

## Testing
- `grep -R "Weidget" -n compose/hs`


------
https://chatgpt.com/codex/tasks/task_e_68444ef857588323aab498cca727b512