### PR TITLE
Add compose validation workflow

### DIFF
--- a/.github/workflows/compose-check.yml
+++ b/.github/workflows/compose-check.yml
@@ -1,0 +1,27 @@
+name: Compose Validation
+
+on:
+  pull_request:
+    paths:
+      - '**docker-compose*.yml'
+      - '.github/workflows/compose-check.yml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Validate docker-compose-hs.yml
+        run: docker compose -f docker-compose-hs.yml config
+      - name: Validate docker-compose-mds.yml
+        if: ${{ hashFiles('docker-compose-mds.yml') != '' }}
+        run: docker compose -f docker-compose-mds.yml config
+      - name: Validate docker-compose-ds918.yml
+        if: ${{ hashFiles('docker-compose-ds918.yml') != '' }}
+        run: docker compose -f docker-compose-ds918.yml config
+      - name: Validate docker-compose-ws.yml
+        if: ${{ hashFiles('docker-compose-ws.yml') != '' }}
+        run: docker compose -f docker-compose-ws.yml config
+      - name: Validate docker-compose-dns.yml
+        if: ${{ hashFiles('docker-compose-dns.yml') != '' }}
+        run: docker compose -f docker-compose-dns.yml config


### PR DESCRIPTION
## Summary
- add workflow to validate compose files

## Testing
- `docker compose -f docker-compose-hs.yml config` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844cb8acc64832386900e1fbc4bb4d7