### PR TITLE
Add ghost container

### DIFF
--- a/compose/hs/ghost.yml
+++ b/compose/hs/ghost.yml
@@ -30,7 +30,7 @@ services:
       - database__connection__user: root
       - database__connection__password: /run/secrets/mysql_root_password
       - database__connection__database: ghost
-      - url: ghost.shatteredcastl.com
+      - url: https://ghost.$DOMAINNAME
     
     secrets:
       - mysql_root_password

--- a/docker-compose-hs.yml
+++ b/docker-compose-hs.yml
@@ -100,7 +100,7 @@ include:
   # - compose/$HOSTNAME/autoindex.yml
   - compose/$HOSTNAME/homepage.yml
   - compose/$HOSTNAME/phpmyadmin.yml
-  # - compose/$HOSTNAME/ghost.yml
+  - compose/$HOSTNAME/ghost.yml
   # - compose/$HOSTNAME/sitespeed.yml
   # - compose/$HOSTNAME/whoami.yml
   # BACKEND


### PR DESCRIPTION
## Summary
- enable ghost container in HS stack
- point ghost url to `$DOMAINNAME`

## Testing
- `docker compose -f docker-compose-hs.yml config` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68602a249c608323b0cf59674f17c21a